### PR TITLE
Add GitHub Action workflow to run Jest tests of the Next.js app on push and PR

### DIFF
--- a/.github/workflows/push-pr-jest-tests.yml
+++ b/.github/workflows/push-pr-jest-tests.yml
@@ -1,0 +1,20 @@
+name: push-pr-jest-tests
+run-name: Jest tests - ${{ github.ref }} - triggered from ${{ github.event_name }} by @${{ github.actor }}
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install dependencies
+        working-directory: ./app
+        run: npm install
+      - name: Run Jest tests
+        working-directory: ./app
+        run: npm run test
+      - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/push-pr-lint.yml
+++ b/.github/workflows/push-pr-lint.yml
@@ -1,11 +1,11 @@
 name: push-pr-lint
-run-name: ${{ github.ref }} - triggered from ${{ github.event_name }} by @${{ github.actor }}
+run-name: Lint Check - ${{ github.ref }} - triggered from ${{ github.event_name }} by @${{ github.actor }}
 on: [push, pull_request]
 jobs:
   prettier-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
+      - name: Checkout repository code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}

--- a/app/src/app/__tests__/page.test.tsx
+++ b/app/src/app/__tests__/page.test.tsx
@@ -44,9 +44,4 @@ describe("fetchData()", () => {
     expect(mockedAxios.get).toHaveBeenCalled();
     expect(res).toEqual(expected);
   });
-
-  // Failing test to verify the push-pr-jest-tests GitHub Action workflow
-  test("should fail", () => {
-    expect(true).toBe(false);
-  });
 });

--- a/app/src/app/__tests__/page.test.tsx
+++ b/app/src/app/__tests__/page.test.tsx
@@ -44,4 +44,9 @@ describe("fetchData()", () => {
     expect(mockedAxios.get).toHaveBeenCalled();
     expect(res).toEqual(expected);
   });
+
+  // Failing test to verify the push-pr-jest-tests GitHub Action workflow
+  test("should fail", () => {
+    expect(true).toBe(false);
+  });
 });


### PR DESCRIPTION
## Description
This PR introduces a GitHub Action workflow to automatically run Jest tests of the Next.js app on every push and PR to the repository. This ensures that our Jest test suites is executed consistently, helping to maintain code quality and catch issues early through continuous integration.

## Changes
- Set up a new GitHub Action workflow to automatically run Jest tests of the Next.js app on every push and PR to the repository through ` .github/workflows/push-pr-jest-tests.yml`.
- Enhance run-name and fix a typo in the `push-pr-lint` workflow.

## Testing
- Verified that the new GitHub Action workflow runs successfully on passing and failing tests situations.